### PR TITLE
RS-10963: Use esbuildConfigBuilder from ngviz

### DIFF
--- a/esbuild.js
+++ b/esbuild.js
@@ -1,26 +1,7 @@
-var copy = require('esbuild-plugin-copy').default;
+const { esbuildConfigBuilder } = require('@displayr/ngviz');
+const copy = require('esbuild-plugin-copy').default;
+
 require('esbuild').build({
-    entryPoints: ['./src'], // Note that we build straight from TypeScript to get the best sourcemaps.  We still run tsc first because it does actual type checking.
-    bundle: true,
-    sourcemap: true,
-    format: 'cjs',  // Needed to produce something we can eval()
-    target: 'es6',
-    outfile: 'dist/index.js',
+    ...esbuildConfigBuilder(copy),
     external: ['jquery', 'plotly.js'],
-    plugins: [
-        copy({
-            verbose: false,
-            assets: {
-                from: ['./assets/*' ],
-                to: ['./assets'],
-            },
-        }),
-        copy({
-            verbose: false,
-            assets: {
-                from: ['ngviz.json' ],
-                to: ['.'],
-            },
-        }),
-    ],
-}).catch((err) => process.exit(1))
+}).catch(() => process.exit(1));

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@displayr/ngviz-api-demonstrator",
-  "version": "1.0.11",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@displayr/ngviz-api-demonstrator",
-  "version": "1.0.11",
+  "version": "1.1.0",
   "description": "As simple as possible an ngviz that demonstrates writing an ngviz against the API, without delving into all the different control types",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
This PR makes use of the esbuildConfigBuilder that lives in ngviz. This allows us to have that common code shared between all ngvizes.

This does have the side effect of this ngviz output being in the iife format instead of cjs but this is a desired side effect as it removes an issue we are having in Displayr with scoping and clashes between different ngvizes which an iife resolves. As a result I am bumping minor (ideally this would be a major but I'm happy to keep major 0 until we release.