### PR TITLE
FS2-1036 Add `deploy-blobs-tag` next parameter 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,4 +47,4 @@ jobs:
                   curl --request POST https://circleci.com/api/v2/project/gh/Displayr/ngviz-server/pipeline \
                     --header "Circle-Token: $CIRCLE_API_TOKEN" \
                     --header "content-type: application/json" \
-                    --data  '{"branch":"master","parameters":{"deploy-blobs":true}}'
+                    --data  '{"branch":"master","parameters":{"deploy-blobs":true, "deploy-blobs-tag": "next"}}'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@displayr/ngviz-api-demonstrator",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@displayr/ngviz-api-demonstrator",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "As simple as possible an ngviz that demonstrates writing an ngviz against the API, without delving into all the different control types",
   "keywords": [],
   "homepage": "https://github.com/Displayr/ngviz-api-demonstrator#readme",


### PR DESCRIPTION
https://numbers.atlassian.net/browse/FS2-1035

This parameter triggers the `deploy-blobs` pipeline to Only publish the @next assets/metadata (Dev CDN blob storage) on master branch

Testing `next` param for `deploy-blobs` pipeline:
https://app.circleci.com/pipelines/github/Displayr/ngviz-api-demonstrator/16/workflows/e835452e-1f39-4e49-b2ff-4377211c9acc/jobs/16
![image](https://user-images.githubusercontent.com/120340342/227405148-a57f763b-c608-4b9d-8793-80f37618b967.png)

https://app.circleci.com/pipelines/github/Displayr/ngviz-server/742/workflows/f5734570-b700-4c5b-9fac-ec8be927f657
![image](https://user-images.githubusercontent.com/120340342/227405273-d3a08e85-d554-430b-b5f5-b76eb7d25d1e.png)
