### PR TITLE
RS-14531: Await css loading before rendering

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@displayr/ngviz-api-demonstrator",
-  "version": "1.2.8",
+  "version": "1.2.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@displayr/ngviz-api-demonstrator",
-      "version": "1.2.8",
+      "version": "1.2.9",
       "license": "UNLICENSED",
       "devDependencies": {
         "@displayr/ngviz": "^4.6.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@displayr/ngviz-api-demonstrator",
-  "version": "1.2.8",
+  "version": "1.2.9",
   "description": "As simple as possible an ngviz that demonstrates writing an ngviz against the API, without delving into all the different control types",
   "keywords": [],
   "homepage": "https://github.com/Displayr/ngviz-api-demonstrator#readme",


### PR DESCRIPTION
My previous fix did not seem to address this issue. It was actually not caused by `renderFinished` being called too early, but it appears to have been a race condition where the plot was sometimes being rendered before styling is applied. We now await `addCssReference` before rendering, and this seems to fix the problem (I could no longer replicate it in the embedding preview or exporting, whereas previously it happened quite consistently).