### PR TITLE
FS2-1110: Move primary data input to Data tab

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@displayr/ngviz-api-demonstrator",
-  "version": "1.2.9",
+  "version": "1.2.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@displayr/ngviz-api-demonstrator",
-      "version": "1.2.9",
+      "version": "1.2.10",
       "license": "UNLICENSED",
       "devDependencies": {
         "@displayr/ngviz": "^4.6.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@displayr/ngviz-api-demonstrator",
-  "version": "1.2.9",
+  "version": "1.2.10",
   "description": "As simple as possible an ngviz that demonstrates writing an ngviz against the API, without delving into all the different control types",
   "keywords": [],
   "homepage": "https://github.com/Displayr/ngviz-api-demonstrator#readme",

--- a/src/NgvizApiDemonstrator.ts
+++ b/src/NgvizApiDemonstrator.ts
@@ -148,7 +148,7 @@ export default class NgvizApiDemonstrator implements INgviz<ViewState> {
         this.dropBox = this.settings.dropBox({
             label: 'Dropdown (called primaryData)',
             name: 'primaryData',
-            page: 'Inputs',
+            page: 'Data',
             group: 'Data Source',
             multi: true,
             types: types_available.split(';').map(s => s.trim()).filter(Boolean),


### PR DESCRIPTION
We want to make the data preview only appear on the Data tab. Adding the data tab will allow us to test it. I don't expect regression tests to break from this but we can deal with it when it happens.