### PR TITLE
Revert "FS2-1110: Move primary data input to Data tab (#15)"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@displayr/ngviz-api-demonstrator",
-  "version": "1.2.10",
+  "version": "1.2.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@displayr/ngviz-api-demonstrator",
-      "version": "1.2.10",
+      "version": "1.2.9",
       "license": "UNLICENSED",
       "devDependencies": {
         "@displayr/ngviz": "^4.6.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@displayr/ngviz-api-demonstrator",
-  "version": "1.2.9",
+  "version": "1.2.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@displayr/ngviz-api-demonstrator",
-      "version": "1.2.9",
+      "version": "1.2.11",
       "license": "UNLICENSED",
       "devDependencies": {
         "@displayr/ngviz": "^4.6.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@displayr/ngviz-api-demonstrator",
-  "version": "1.2.9",
+  "version": "1.2.11",
   "description": "As simple as possible an ngviz that demonstrates writing an ngviz against the API, without delving into all the different control types",
   "keywords": [],
   "homepage": "https://github.com/Displayr/ngviz-api-demonstrator#readme",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@displayr/ngviz-api-demonstrator",
-  "version": "1.2.10",
+  "version": "1.2.9",
   "description": "As simple as possible an ngviz that demonstrates writing an ngviz against the API, without delving into all the different control types",
   "keywords": [],
   "homepage": "https://github.com/Displayr/ngviz-api-demonstrator#readme",

--- a/src/NgvizApiDemonstrator.ts
+++ b/src/NgvizApiDemonstrator.ts
@@ -148,7 +148,7 @@ export default class NgvizApiDemonstrator implements INgviz<ViewState> {
         this.dropBox = this.settings.dropBox({
             label: 'Dropdown (called primaryData)',
             name: 'primaryData',
-            page: 'Data',
+            page: 'Inputs',
             group: 'Data Source',
             multi: true,
             types: types_available.split(';').map(s => s.trim()).filter(Boolean),


### PR DESCRIPTION
This reverts commit 6e16e54b1725a03e4c486faecd4fb73854f0d23d.

The migration to the Data tab will occur later with https://numbers.atlassian.net/browse/FS2-1594