### PR TITLE
FS2-1629 Reference implementation of input data errors reporting.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@displayr/ngviz-api-demonstrator",
-  "version": "1.2.14",
+  "version": "1.2.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@displayr/ngviz-api-demonstrator",
-      "version": "1.2.14",
+      "version": "1.2.15",
       "license": "UNLICENSED",
       "devDependencies": {
         "@displayr/ngviz": "^4.6.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@displayr/ngviz-api-demonstrator",
-  "version": "1.2.14",
+  "version": "1.2.15",
   "description": "As simple as possible an ngviz that demonstrates writing an ngviz against the API, without delving into all the different control types",
   "keywords": [],
   "homepage": "https://github.com/Displayr/ngviz-api-demonstrator#readme",


### PR DESCRIPTION
This PR demonstrates how data merge error can be handled/reported in an ngviz.

While other implementations are definitely possible, an important piece is to not report errors with messages beginning with `"IGNORE|"` as these are just placeholders that are there due to the API requiring either data or error for every input selected in the input selection dropbox.

This is how the errors look (note that errors above the Object Inspector match the errors in the JSON displayed by the ngviz-api-demonstrator):
![image](https://github.com/Displayr/ngviz-api-demonstrator/assets/117244975/ff55c1bd-db3b-422d-96ff-95ed27048613)
