### PR TITLE
FS2-1583 Change the name of switchRowsColumns checkbox control to match Data Tab's back end logic.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@displayr/ngviz-api-demonstrator",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@displayr/ngviz-api-demonstrator",
-      "version": "1.3.1",
+      "version": "1.3.2",
       "license": "UNLICENSED",
       "devDependencies": {
         "@displayr/ngviz": "^13.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@displayr/ngviz-api-demonstrator",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "As simple as possible an ngviz that demonstrates writing an ngviz against the API, without delving into all the different control types",
   "keywords": [],
   "homepage": "https://github.com/Displayr/ngviz-api-demonstrator#readme",

--- a/src/DataTab.ts
+++ b/src/DataTab.ts
@@ -36,7 +36,7 @@ export function constructDataTab(
 
     if (config?.switchRowColumn) {
         const switch_rows = data_control_creator.checkBox({
-            name: 'switchRowsColumns',
+            name: 'dataTab_2_switchRowsAndColumns',
             label: 'Switch rows/columns',
             ...config.switchRowColumn,
         });


### PR DESCRIPTION
For Data Tab back end to work properly, it needs to know which controls are part of the Data Tab and what's their order. This is, at least for now, encoded in the control names. The name for the "Switch rows/columns" checkbox should be "dataTab_2_switchRowsAndColumns".